### PR TITLE
Change default port to 2323

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,8 @@ fn main() {
 
     Process::spawn_with(state_receiver, server::server_process).detach();
 
-    let port = matches.value_of("PORT").unwrap_or("23");
+    let port = matches.value_of("PORT").unwrap_or("8080");
+    println!("Started server on port {}", port);
     let address = format!("0.0.0.0:{}", port);
     let listener = TcpListener::bind(address).unwrap();
     while let Ok(tcp_stream) = listener.accept() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
 
     Process::spawn_with(state_receiver, server::server_process).detach();
 
-    let port = matches.value_of("PORT").unwrap_or("8080");
+    let port = matches.value_of("PORT").unwrap_or("2323");
     println!("Started server on port {}", port);
     let address = format!("0.0.0.0:{}", port);
     let listener = TcpListener::bind(address).unwrap();


### PR DESCRIPTION
Running an application with a port lower than 1024 requires root privileges on linux. Changing it to something like 8080 allows running the example without having to use sudo.