### PR TITLE
Switch instead of add if tab already exists

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -145,7 +145,7 @@ impl ProcessMessage<TelnetCommand> for ClientProcess {
                                 None,
                                 TabType::Info(instructions.render().unwrap()),
                             );
-                            state.tabs.add(tab);
+                            state.tabs.add_or_switch(tab);
                             state.ui.render();
                         }
                         "/nick" => {
@@ -164,7 +164,7 @@ impl ProcessMessage<TelnetCommand> for ClientProcess {
                                 None,
                                 TabType::Info(list.render().unwrap()),
                             );
-                            state.tabs.add(tab);
+                            state.tabs.add_or_switch(tab);
                             state.ui.render();
                         }
                         "/drop" => {
@@ -199,7 +199,7 @@ impl ProcessMessage<TelnetCommand> for ClientProcess {
                                     Some(channel),
                                     TabType::Channel(last_messages),
                                 );
-                                state.tabs.add(tab);
+                                state.tabs.add_or_switch(tab);
                             } else {
                                 // Incorrect channel name
                             }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -195,6 +195,21 @@ impl UiTabs {
         mutable.selected = mutable.tabs.len() - 1;
     }
 
+    pub fn switch(&self, name: &str) {
+        if let Some(index) = self.names().iter().position(|n| &n == &&name) {
+            let mut mutable = self.inner.as_ref().borrow_mut();
+            mutable.selected = index;
+        }
+    }
+
+    pub fn add_or_switch(&self, tab: Tab) {
+        if self.names().contains(&tab.name) {
+            self.switch(&tab.name);
+        } else {
+            self.add(tab);
+        }
+    }
+
     pub fn drop(&self) {
         let mut mutable = self.inner.as_ref().borrow_mut();
         // Don't drop the last tab
@@ -258,7 +273,7 @@ impl UiTabs {
         selected.clear()
     }
 
-    pub fn _names(&self) -> Vec<String> {
+    pub fn names(&self) -> Vec<String> {
         let immutable = self.inner.as_ref().borrow();
         immutable.tabs.iter().map(|tab| tab.name.clone()).collect()
     }


### PR DESCRIPTION
Adds a new `switch` that switches to a tab by name, and `add_or_switch` that adds or switches whenever appropriate. It also changes the command processor to use `add_or_switch` for information and channel tabs.

This should make tabs slightly less confusing to use.

The tabs are still prepared before checking if it already exists. This might not be your preferred behavior, and can be refactored if so desired.

Resolves part of #1