### PR TITLE
Refactor to use abstract_process macro

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
-use lunatic::process::{AbstractProcess, Message, MessageHandler, ProcessRef, RequestHandler};
-use serde::{Deserialize, Serialize};
+use lunatic::{abstract_process, process::ProcessRef};
 
-use crate::client::{ChannelMessage, ClientProcess};
+use crate::client::{ClientProcess, ClientProcessHandler};
 
 /// A channel dispatches messages to all clients that are part of it.
 ///
@@ -13,69 +12,58 @@ pub struct ChannelProcess {
     last_messages: Vec<(String, String, String)>,
 }
 
-impl AbstractProcess for ChannelProcess {
-    type Arg = String;
-    type State = Self;
-
-    fn init(_: ProcessRef<Self>, _name: Self::Arg) -> Self::State {
+#[abstract_process]
+impl ChannelProcess {
+    #[init]
+    fn init(_: ProcessRef<Self>, _name: String) -> Self {
         ChannelProcess {
             clients: HashMap::new(),
             last_messages: Vec::new(),
         }
     }
-}
 
-/// A `Join` message is sent by clients that would like to join the channel.
-///
-/// It contains a reference to the client.
-#[derive(Serialize, Deserialize)]
-pub struct Join(pub ProcessRef<ClientProcess>);
-impl MessageHandler<Join> for ChannelProcess {
-    fn handle(state: &mut Self::State, Join(client): Join) {
-        state.clients.insert(client.id(), client);
+    /// join the channel.
+    #[handle_message]
+    fn join(&mut self, client: ProcessRef<ClientProcess>) {
+        self.clients.insert(client.id(), client);
     }
-}
 
-/// Returns up to 10 last messages received by the channel.
-#[derive(Serialize, Deserialize)]
-pub struct LastMessages;
-impl RequestHandler<LastMessages> for ChannelProcess {
-    type Response = Vec<(String, String, String)>;
-
-    fn handle(state: &mut Self::State, _: LastMessages) -> Self::Response {
-        state.last_messages.clone()
+    /// leave the channel.
+    #[handle_message]
+    fn leave(&mut self, client: ProcessRef<ClientProcess>) {
+        self.clients.remove(&client.id());
     }
-}
 
-/// A `Leave` message is sent by clients that would like to leave the channel.
-///
-/// It contains a reference to the client.
-#[derive(Serialize, Deserialize)]
-pub struct Leave(pub ProcessRef<ClientProcess>);
-impl MessageHandler<Leave> for ChannelProcess {
-    fn handle(state: &mut Self::State, Leave(client): Leave) {
-        state.clients.remove(&client.id());
+    /// Returns up to 10 last messages received by the channel.
+    #[handle_request]
+    fn get_last_messages(&mut self) -> Vec<(String, String, String)> {
+        self.last_messages.clone()
     }
-}
 
-/// A new message sent to the channel.
-///
-/// It contains ("", timestamp, name, message content).
-///
-/// The first argument is reserved for the name
-impl MessageHandler<ChannelMessage> for ChannelProcess {
-    fn handle(state: &mut Self::State, message: ChannelMessage) {
+    /// Sent a new message to the channel.
+    #[handle_message]
+    fn broadcast_message(
+        &mut self,
+        channel: String,
+        timestamp: String,
+        name: String,
+        message: String,
+    ) {
         // Save
-        state
-            .last_messages
-            .push((message.1.clone(), message.2.clone(), message.3.clone()));
+        self.last_messages
+            .push((timestamp.clone(), name.clone(), message.clone()));
         // If too many last messages, drain
-        if state.last_messages.len() > 10 {
-            state.last_messages.drain(0..5);
+        if self.last_messages.len() > 10 {
+            self.last_messages.drain(0..5);
         }
         // Broadcast message to all clients
-        for (_id, client) in state.clients.iter() {
-            let _ = client.send(message.clone());
+        for (_id, client) in self.clients.iter() {
+            let _ = client.receive_message(
+                channel.clone(),
+                timestamp.clone(),
+                name.clone(),
+                message.clone(),
+            );
         }
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -17,13 +17,10 @@ use tui::{
     widgets::{Block, Borders, Tabs},
 };
 
-use lunatic::{
-    net::TcpStream,
-    process::{Message, ProcessRef},
-};
+use lunatic::{net::TcpStream, process::ProcessRef};
 use telnet_backend::TelnetBackend;
 
-use crate::{channel::ChannelProcess, client::ChannelMessage};
+use crate::channel::{ChannelProcess, ChannelProcessHandler};
 
 pub struct Ui {
     terminal: Terminal<TelnetBackend>,
@@ -327,7 +324,7 @@ impl Tab {
 
     pub fn message(&self, timestamp: String, user: String, message: String) {
         if let Some(notifier) = &self.notifier {
-            notifier.send(ChannelMessage(self.name.clone(), timestamp, user, message));
+            notifier.broadcast_message(self.name.clone(), timestamp, user, message);
         }
     }
 }


### PR DESCRIPTION
# Refactor to use abstract_process macro
Refactored all `AbstractProcess` implementations to the new `abstract_process` macro.
- Removed almost all message struct definitions.
- Updated the docstrings for the handlers.